### PR TITLE
Fix required field, changed from pass to password

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export const configurationSchema = {
       },
 
       additionalProperties: false,
-      required: ['host', 'user', 'pass']
+      required: ['host', 'user', 'password']
     }
   },
 


### PR DESCRIPTION
this one was missed on https://github.com/vatesfr/xo-server-transport-email/commit/7af5964f131d454fc6b34a27f54ad9f6558c6575
